### PR TITLE
feat: add a common logger

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -1,0 +1,1 @@
+extends: screwdriver

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+artifacts/
+npm-debug.log
+.DS_STORE
+.*.swp
+.nyc_output
+package-lock.json

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright 2019 Yahoo
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/index.js
+++ b/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const winston = require('winston');
+
+const logger = winston.createLogger({
+    level: process.env.LOG_LEVEL || 'info',
+    transports: [
+        new (winston.transports.Console)({ timestamp: true })
+    ]
+});
+
+module.exports = logger;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "screwdriver-logger",
+  "version": "1.0.0",
+  "description": "Porvides common logger for Screwdriver components",
+  "main": "index.js",
+  "scripts": {
+    "pretest": "eslint .",
+    "test": "jenkins-mocha --recursive",
+    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/screwdriver-cd/logger.git"
+  },
+  "keywords": [
+    "screwdriver",
+    "yahoo"
+  ],
+  "author": "https://github.com/jithine",
+  "license": "BSD-3-Clause",
+  "bugs": {
+    "url": "https://github.com/screwdriver-cd/logger/issues"
+  },
+  "homepage": "https://github.com/screwdriver-cd/logger#readme",
+  "dependencies": {
+    "winston": "^3.2.1"
+  },
+  "release": {
+    "debug": false,
+    "verifyConditions": {
+      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
+    }
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "eslint": "^4.19.1",
+    "eslint-config-screwdriver": "^3.0.1",
+    "jenkins-mocha": "^8.0.0",
+    "mockery": "^2.1.0",
+    "sinon": "^7.5.0"
+  }
+}

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,0 +1,18 @@
+shared:
+    image: node:8
+
+jobs:
+    main:
+        requires: [~pr, ~commit]
+        steps:
+            - install: npm install
+            - test: npm test
+
+    publish:
+        requires: [main]
+        template: screwdriver-cd/semantic-release
+        secrets:
+            # Publishing to NPM
+            - NPM_TOKEN
+            # Pushing tags to Git
+            - GH_TOKEN

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,52 @@
+'use strict';
+
+/* eslint-disable no-underscore-dangle */
+
+const chai = require('chai');
+const assert = chai.assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
+
+sinon.assert.expose(chai.assert, { prefix: '' });
+
+describe('index test', () => {
+    let winstonMock;
+
+    before(() => {
+        mockery.enable({
+            useCleanCache: true,
+            warnOnUnregistered: false
+        });
+    });
+
+    beforeEach(() => {
+        winstonMock = {
+            info: sinon.stub(),
+            error: sinon.stub()
+        };
+        mockery.registerMock('winston', {
+            createLogger: () => winstonMock,
+            transports: {
+                Console: sinon.stub()
+            }
+        });
+    });
+
+    afterEach(() => {
+        mockery.deregisterAll();
+        mockery.resetCache();
+    });
+
+    after(() => {
+        mockery.disable();
+    });
+
+    it('tests logger', () => {
+        const logger = require('../index.js'); // eslint-disable-line global-require
+
+        logger.error('this is an error');
+
+        assert.calledOnce(winstonMock.error);
+        assert.calledWith(winstonMock.error, 'this is an error');
+    });
+});


### PR DESCRIPTION
## Context

Add a new common logger which can be used by all other modules.

## Objective

Each SD module is instantiating it's own logger. Provide a common logger which all modules can use without worrying about all the initialization aspects.

## References

Will modify following PRs to use common logger once this is available 

https://github.com/screwdriver-cd/models/pull/411
https://github.com/screwdriver-cd/screwdriver/pull/1851

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
