### PR TITLE
fix: support string interpolation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,15 @@
 'use strict';
 
-const winston = require('winston');
+const { createLogger, format, transports } = require('winston');
 
-const logger = winston.createLogger({
+const logger = createLogger({
     level: process.env.LOG_LEVEL || 'info',
+    format: format.combine(
+        format.splat(),
+        format.json()
+    ),
     transports: [
-        new (winston.transports.Console)({ timestamp: true })
+        new (transports.Console)({ timestamp: true })
     ]
 });
 

--- a/index.js
+++ b/index.js
@@ -5,11 +5,12 @@ const { createLogger, format, transports } = require('winston');
 const logger = createLogger({
     level: process.env.LOG_LEVEL || 'info',
     format: format.combine(
+        format.timestamp(),
         format.splat(),
         format.json()
     ),
     transports: [
-        new (transports.Console)({ timestamp: true })
+        new (transports.Console)()
     ]
 });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -28,7 +28,8 @@ describe('index test', () => {
             format: {
                 splat: sinon.stub(),
                 json: sinon.stub(),
-                combine: sinon.stub()
+                combine: sinon.stub(),
+                timestamp: sinon.stub()
             },
             createLogger: () => winstonMock,
             transports: {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,11 @@ describe('index test', () => {
             error: sinon.stub()
         };
         mockery.registerMock('winston', {
+            format: {
+                splat: sinon.stub(),
+                json: sinon.stub(),
+                combine: sinon.stub()
+            },
             createLogger: () => winstonMock,
             transports: {
                 Console: sinon.stub()


### PR DESCRIPTION
## Context

We use string interpolation in logging. Current logger needs to enable support.

## Objective

Add format options to logger.

## References

https://github.com/screwdriver-cd/screwdriver/blob/master/bin/server#L221 will now create a log like the following

```
{"level":"info","message":"Server running at http://localhost:80","timestamp":"2019-11-22T20:27:54.453Z"}
```

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
