### PR TITLE
feat: Remove color in logs, update semantic-release config

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const { createLogger, format, transports } = require('winston');
 
 const logger = createLogger({
     level: process.env.LOG_LEVEL || 'info',
-    format: format.combine(format.timestamp(), format.splat(), format.json()),
+    format: format.combine(format.uncolorize(), format.timestamp(), format.splat(), format.json()),
     transports: [new transports.Console()]
 });
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "index.js",
   "scripts": {
     "pretest": "eslint .",
-    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true"
   },
   "repository": {
     "type": "git",
@@ -33,23 +32,20 @@
   },
   "homepage": "https://github.com/screwdriver-cd/logger#readme",
   "dependencies": {
-    "winston": "^3.2.1"
+    "winston": "^3.8.2"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   },
   "devDependencies": {
-    "chai": "^4.2.0",
-    "eslint": "^7.5.0",
+    "chai": "^4.3.6",
+    "eslint": "^7.32.0",
     "eslint-config-screwdriver": "^5.0.1",
     "mocha": "^8.2.1",
     "mocha-multi-reporters": "^1.5.1",
     "mocha-sonarqube-reporter": "^1.0.2",
-    "nyc": "^15.0.0",
     "mockery": "^2.1.0",
+    "nyc": "^15.0.0",
     "sinon": "^9.2.4"
   }
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -29,7 +29,8 @@ describe('index test', () => {
                 splat: sinon.stub(),
                 json: sinon.stub(),
                 combine: sinon.stub(),
-                timestamp: sinon.stub()
+                timestamp: sinon.stub(),
+                uncolorize: sinon.stub()
             },
             createLogger: () => winstonMock,
             transports: {


### PR DESCRIPTION
## Context

It can be annoying parsing logs with ansi color when the monitoring tools cannot handle it.

## Objective

This PR removes color from logs.

## References
https://github.com/winstonjs/logform/blob/master/README.md#uncolorize

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
